### PR TITLE
Allow sending custom JSON message

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ Send a push notification to your app using token-based authentication:
         -token c7b68e4eb7d604876bf5836133479ffa49449c669f7e6b79318ae59032e83c24 \
         -topic com.my.app
 
+Send a custom push notification to your app using token-based authentication with the JSON message specified in the command line:
+
+    apnscmd_linux_amd64 -auth-token AuthKey_BBC42Y2321.p8 -key-id BBC42Y2321 -team-id YXB7430FC8 \
+        -token c7b68e4eb7d604876bf5836133479ffa49449c669f7e6b79318ae59032e83c24 \
+        -topic com.my.app -alert-json '{"aps": {"alert" : "test", "sound": "default"}, "custom":"custom value"}'
+
+
+Send a custom push notification to your app using token-based authentication with the JSON message read from a file:
+
+    apnscmd_linux_amd64 -auth-token AuthKey_BBC42Y2321.p8 -key-id BBC42Y2321 -team-id YXB7430FC8 \
+        -token c7b68e4eb7d604876bf5836133479ffa49449c669f7e6b79318ae59032e83c24 \
+        -topic com.my.app -alert-filename custom.json
+
+
 Show all available arguments:
 
     apnscmd_linux_amd64 -h


### PR DESCRIPTION
This tool is handy, but I need to specify custom JSON while testing an app that uses CleverTap. As you can see here, CleverTap has some extra values for the JSON message:

https://docs.clevertap.com/docs/faq#q-what-is-the-format-of-the-payload-of-the-push-notification-for-ios

So I added two new options: to use custom JSON from the command line or to read the JSON from a file.