### PR TITLE
Added apns-push-type parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func init() {
 	flag.BoolVar(&IsExplicitTrust, "x-trust", false, "Explicitly trust Geo Trust CA and Apple IST CA 2 root certificates (Usually you should not need to do this)")
 	flag.StringVar(&DeviceToken, "token", "", "Required. Hexadecimal or Base64 encoded push token for the device")
 	flag.StringVar(&PushTopic, "topic", "", "Required. The topic the device subscribes to")
-	flag.StringVar(&PushType, "type", "", "The value of the apns-push-type. Possible vaules are: alert background location voip complication fileprovider mdm liveactivity'.  Default is 'alert'")
+	flag.StringVar(&PushType, "type", "", "The value of the apns-push-type. Possible vaules are: 'alert', 'background', 'location', 'voip', 'complication', 'fileprovider', 'mdm', 'liveactivity'.  Default is 'alert'")
 	flag.StringVar(&MdmPushMagic, "mdm-magic", "", "The magic string that has to be included in the push notification message")
 	flag.StringVar(&PushAlertMessage, "alert-text", "Hello from app-push-cmd!", "Alert text to display for app push notifications")
 	flag.StringVar(&PushAlertJSON, "alert-json", "", "If this is set, this raw JSON will be sent instead of alert-text")

--- a/main.go
+++ b/main.go
@@ -104,6 +104,8 @@ var (
 	DeviceToken string
 	// PushTopic The topic the device subscribes to
 	PushTopic string
+	// The value of the apns-push-type. Default to 'alert'
+	PushType string
 	// MdmPushMagic The magic string that has to be included in the push notification message.
 	MdmPushMagic string
 	// IsSandbox Sends push notification to APNs sandbox at api.sandbox.push.apple.com
@@ -132,6 +134,7 @@ func init() {
 	flag.BoolVar(&IsExplicitTrust, "x-trust", false, "Explicitly trust Geo Trust CA and Apple IST CA 2 root certificates (Usually you should not need to do this)")
 	flag.StringVar(&DeviceToken, "token", "", "Required. Hexadecimal or Base64 encoded push token for the device")
 	flag.StringVar(&PushTopic, "topic", "", "Required. The topic the device subscribes to")
+	flag.StringVar(&PushType, "type", "", "The value of the apns-push-type. Possible vaules are: alert background location voip complication fileprovider mdm liveactivity'.  Default is 'alert'")
 	flag.StringVar(&MdmPushMagic, "mdm-magic", "", "The magic string that has to be included in the push notification message")
 	flag.StringVar(&PushAlertMessage, "alert-text", "Hello from app-push-cmd!", "Alert text to display for app push notifications")
 	flag.StringVar(&PushAlertJSON, "alert-json", "", "If this is set, this raw JSON will be sent instead of alert-text")
@@ -370,6 +373,10 @@ func main() {
 			req.Header.Set("apns-push-type", "mdm")
 		} else {
 			req.Header.Set("apns-push-type", "alert")
+		}
+
+		if len(PushType) > 0 {
+			req.Header.Set("apns-push-type", PushType)
 		}
 
 		if len(bearerToken) > 0 {


### PR DESCRIPTION
This PR adds a parameter to specify the value of the `apns-push-type ` as [per apple docs](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns#2947607)
```
  -type string
    	The value of the apns-push-type. Possible vaules are: alert background location voip complication fileprovider mdm liveactivity'.  Default is 'alert'
```

Fixes https://github.com/petarov/apns-push-cmd/issues/4